### PR TITLE
Added postcss to prevent warnings

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -2,6 +2,7 @@
 
 var cheerio = require('cheerio');
 var autoprefixer = require('autoprefixer');
+var postcss = require('postcss');
 
 var VERSION = require('../package.json').version;
 
@@ -18,7 +19,7 @@ HTMLAutoprefixer.prototype.process = function(htmlString, cheerioOpts, autoprefi
   var prefixed;
 
   styles.each(function(index, style) {
-    prefixed = autoprefixer.process(style.data, autoprefixerOpts).css;
+    prefixed = postcss([autoprefixer]).process(style.data, autoprefixerOpts).css;
     style.data = prefixed;
   });
 
@@ -28,7 +29,7 @@ HTMLAutoprefixer.prototype.process = function(htmlString, cheerioOpts, autoprefi
       tmp += '#tmp' + index + '{' + element.attribs.style + '}';
     });
 
-    prefixed = autoprefixer.process(tmp, autoprefixerOpts).css;
+    prefixed = postcss([autoprefixer]).process(tmp, autoprefixerOpts).css;
 
     var re = this.re;
     elementsWithStyleAttr.each(function(index, element) {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "html",
     "html-autoprefixer",
     "auto-prefixer",
-    "css"
+    "css",
+    "postcss"
   ],
   "readmeFilename": "README.md",
   "author": "motdotla",
@@ -30,6 +31,7 @@
   },
   "dependencies": {
     "autoprefixer": "^5.1.1",
-    "cheerio": "^0.19.0"
+    "cheerio": "^0.19.0",
+    "postcss": "^4.1.11"
   }
 }


### PR DESCRIPTION
Added postcss to avoid the warning below:

`Autoprefixer's process() method is deprecated and will removed in next major release. Use postcss([autoprefixer]).process() instead`